### PR TITLE
Promote the Timeline page to the site root

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,9 +1,9 @@
 # Homepage structure: The Timeline
 
-The chosen structure for the new `ingehap.github.io` homepage, built as a working
-prototype in `concepts/structure-2-timeline/index.html`. (Two alternative
-structures — a filterable dashboard grid and a classic multi-page academic hub —
-were prototyped and rejected in favor of this one.)
+The structure of the `ingehap.github.io` homepage, live at the repository root
+as `index.html`. (Two alternative structures — a filterable dashboard grid and
+a classic multi-page academic hub — were prototyped and rejected in favor of
+this one.)
 
 The page is a single chronological narrative — a window into current work and
 everything that led to it:
@@ -59,7 +59,5 @@ Step-by-step instructions for both the math and the animation pipeline are in
 
 1. Replace the placeholder entries (marked "Example"/"placeholder") with real
    publications and projects — only *Project001 — SR learning* is real today.
-2. Promote the page to the site root as `index.html` and remove the concept
-   banner, making it the live homepage.
-3. Optional later: split entries into a small JSON data file rendered by a few
+2. Optional later: split entries into a small JSON data file rendered by a few
    lines of JS, if hand-editing HTML becomes tedious.

--- a/help.md
+++ b/help.md
@@ -1,9 +1,8 @@
 # Site help: LaTeX math and Python animations
 
 How to put mathematics and script-generated animations on this site. Both
-features are already wired up on the timeline page
-(`concepts/structure-2-timeline/index.html`); this document explains how they
-work and how to use them on any page.
+features are already wired up on the homepage (`index.html` at the repository
+root); this document explains how they work and how to use them on any page.
 
 - [1. LaTeX math with KaTeX](#1-latex-math-with-katex)
 - [2. Python animations with matplotlib → GIF](#2-python-animations-with-matplotlib--gif)
@@ -23,9 +22,9 @@ serves the files as-is — there is no build step.
 Add these lines inside `<head>`:
 
 ```html
-<link rel="stylesheet" href="../../assets/katex/katex.min.css">
-<script defer src="../../assets/katex/katex.min.js"></script>
-<script defer src="../../assets/katex/contrib/auto-render.min.js"
+<link rel="stylesheet" href="assets/katex/katex.min.css">
+<script defer src="assets/katex/katex.min.js"></script>
+<script defer src="assets/katex/contrib/auto-render.min.js"
   onload="renderMathInElement(document.body, {delimiters: [
     {left: '$$', right: '$$', display: true},
     {left: '\\(', right: '\\)', display: false}
@@ -38,7 +37,7 @@ Add these lines inside `<head>`:
 |---|---|
 | repository root (`index.html`) | `assets/katex/…` |
 | one level deep (`concepts/…`) | `../assets/katex/…` |
-| two levels deep (`concepts/structure-2-timeline/…`) | `../../assets/katex/…` |
+| two levels deep (`concepts/<page>/…`) | `../../assets/katex/…` |
 
 The `defer` attributes keep the scripts from blocking the page; `auto-render`
 scans the document once it loads and typesets everything between the
@@ -187,7 +186,7 @@ The moving parts:
 
 ```html
 <figure class="media">
-  <img src="../../assets/anim/sine-wave.gif" width="420" height="260"
+  <img src="assets/anim/sine-wave.gif" width="420" height="260"
        loading="lazy"
        alt="Traveling sine wave animation">
 </figure>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Concept 2 · The Timeline</title>
-<link rel="stylesheet" href="../../assets/katex/katex.min.css">
-<script defer src="../../assets/katex/katex.min.js"></script>
-<script defer src="../../assets/katex/contrib/auto-render.min.js"
+<title>Inge Hap</title>
+<meta name="description" content="Inge Hap — interpretable machine learning for materials: symbolic regression, magnetic anisotropy, and open-source research tooling.">
+<link rel="stylesheet" href="assets/katex/katex.min.css">
+<script defer src="assets/katex/katex.min.js"></script>
+<script defer src="assets/katex/contrib/auto-render.min.js"
   onload="renderMathInElement(document.body, {delimiters: [
     {left: '$$', right: '$$', display: true},
     {left: '\\(', right: '\\)', display: false}
@@ -23,8 +24,6 @@
     --accent-soft: #e3ecdf;
     --paper-dot: #3d6b4f;
     --soft-dot: #a8862c;
-    --notice-bg: #26291f;
-    --notice-ink: #e6e6dc;
     --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -41,8 +40,6 @@
       --accent-soft: #26372c;
       --paper-dot: #8fbf9f;
       --soft-dot: #d4b25e;
-      --notice-bg: #0f110d;
-      --notice-ink: #b9bcae;
     }
   }
   :root[data-theme="dark"] {
@@ -56,8 +53,6 @@
     --accent-soft: #26372c;
     --paper-dot: #8fbf9f;
     --soft-dot: #d4b25e;
-    --notice-bg: #0f110d;
-    --notice-ink: #b9bcae;
   }
   :root[data-theme="light"] {
     --bg: #f7f6f2;
@@ -70,8 +65,6 @@
     --accent-soft: #e3ecdf;
     --paper-dot: #3d6b4f;
     --soft-dot: #a8862c;
-    --notice-bg: #26291f;
-    --notice-ink: #e6e6dc;
   }
 
   * { box-sizing: border-box; }
@@ -85,13 +78,6 @@
   }
   a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
   a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-
-  .notice {
-    background: var(--notice-bg); color: var(--notice-ink);
-    font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.06em;
-    text-align: center; padding: 0.5rem 1rem;
-  }
-  .notice strong { color: #fff; font-weight: 600; }
 
   .wrap { max-width: 60rem; margin: 0 auto; padding: 0 1.25rem; }
 
@@ -177,8 +163,6 @@
 </style>
 </head>
 <body>
-<div class="notice"><strong>Structure concept 2 of 3 — “The Timeline”.</strong> Single page, chronological narrative. All names, papers, and projects below are placeholders.</div>
-
 <header class="site">
   <div class="wrap">
     <h1>Inge Hap</h1>
@@ -230,7 +214,7 @@
           <p class="venue">Python script · matplotlib animation rendered to GIF</p>
           <p class="desc">Placeholder software item demonstrating an embedded animation: a Python script (<code>scripts/anisotropy_animation.py</code>) renders the energy surface \(E_{\mathrm{a}}(\theta)\) with matplotlib's <code>FuncAnimation</code> and writes a looping GIF with the Pillow writer. As \(K_1/K_2\) sweeps, the easy directions (gold dots) migrate from axis to cone to plane.</p>
           <figure class="media">
-            <img src="../../assets/anim/anisotropy-energy.gif" width="420" height="420" loading="lazy" alt="Animated polar plot of the uniaxial anisotropy energy surface; gold markers show the easy directions moving between the easy-axis, easy-cone and easy-plane regimes as K1/K2 sweeps">
+            <img src="assets/anim/anisotropy-energy.gif" width="420" height="420" loading="lazy" alt="Animated polar plot of the uniaxial anisotropy energy surface; gold markers show the easy directions moving between the easy-axis, easy-cone and easy-plane regimes as K1/K2 sweeps">
           </figure>
           <div class="links"><a href="https://github.com/ingehap/ingehap.github.io/blob/main/scripts/anisotropy_animation.py">Python script</a></div>
         </article>


### PR DESCRIPTION
## Summary

Makes the Timeline the live homepage at `https://ingehap.github.io/`:

- **Moved** `concepts/structure-2-timeline/index.html` → `index.html` (git rename, so history follows the file)
- **Paths** — KaTeX assets and the animation GIF now use root-relative paths (`assets/…` instead of `../../assets/…`)
- **Banner dropped** — the "Structure concept 2 of 3" notice bar and its now-unused CSS (`.notice` rules and `--notice-*` tokens) are removed
- **Head polish** — real `<title>` ("Inge Hap") and a `<meta name="description">` for search/link previews
- **Docs updated** — `CONCEPTS.md` and `help.md` now reference the root page; the completed "promote to root" next-step is removed

Verified headlessly after the move: KaTeX renders the equations, the animation GIF loads, and no `../` paths or banner markup remain.

Note: the page still contains the placeholder entries (marked "Example"/"placeholder") — replacing them with real publications and projects is the remaining step, but after this merge the placeholders are visible at the public root URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvT3jBjgB7a8vhxGZiiQ9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvT3jBjgB7a8vhxGZiiQ9v)_