### PR TITLE
Add 2026 course entry: Codex Course with RealPython

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,11 @@
     <div class="stream">
       <section class="yearblock" id="y2026" aria-label="2026">
         <h2>2026</h2>
+        <article class="entry course">
+          <h3>Codex Course with RealPython</h3>
+          <p class="venue">Course · RealPython · 2026</p>
+          <div class="links"><a href="https://realpython.com">RealPython</a></div>
+        </article>
         <article class="entry paper">
           <h3>Example: preprint under review</h3>
           <p class="venue">arXiv preprint · under review</p>


### PR DESCRIPTION
Adds a course entry titled "Codex Course with RealPython" to the 2026 section of the timeline in `index.html`.

- New `entry course` article at the top of the 2026 year block, using the existing course styling (blue diamond marker already defined in the CSS and legend).
- Venue line reads "Course · RealPython · 2026" with a link to realpython.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XVoKzEBzWbxoWmne4KEUt

---
_Generated by [Claude Code](https://claude.ai/code/session_011XVoKzEBzWbxoWmne4KEUt)_