### PR TITLE
Add urls.html with anchored section navigation

### DIFF
--- a/urls.html
+++ b/urls.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>URLs</title>
+<style>
+  body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 60rem; margin: 0 auto; padding: 1.25rem; }
+  nav.toc { display: flex; gap: 1.5rem; border-bottom: 1px solid #ccc; padding-bottom: 0.75rem; }
+</style>
+</head>
+<body>
+<nav class="toc" aria-label="Sections">
+  <a href="#cs">CS</a>
+  <a href="#e">E</a>
+  <a href="#es">ES</a>
+  <a href="#f">F</a>
+  <a href="#m">M</a>
+  <a href="#rw">RW</a>
+  <a href="#ss">SS</a>
+  <a href="#t">T</a>
+</nav>
+
+<h2 id="cs">CS</h2>
+
+<h2 id="e">E</h2>
+
+<h2 id="es">ES</h2>
+
+<h2 id="f">F</h2>
+
+<h2 id="m">M</h2>
+
+<h2 id="rw">RW</h2>
+
+<h2 id="ss">SS</h2>
+
+<h2 id="t">T</h2>
+
+</body>
+</html>


### PR DESCRIPTION
Adds a new standalone page `urls.html`:

- A single horizontal nav line at the top with the links CS, E, ES, F, M, RW, SS, T.
- Each link jumps to a matching `<h2>` heading further down the same page, in that order, ready to be filled with URL lists per section.
- Minimal inline styling only (system font, flex nav row with a bottom rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XVoKzEBzWbxoWmne4KEUt

---
_Generated by [Claude Code](https://claude.ai/code/session_011XVoKzEBzWbxoWmne4KEUt)_